### PR TITLE
Integrate configurable Ollama client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ SynthMind is a multimodal chat application that combines a large language model 
 
 - Chat interface with tabs for Chat, Personas, App Settings, and Model Selection
 - Ollama-backed LLM integration with model downloader
+- Configurable Ollama host via the `OLLAMA_HOST` environment variable
 - Placeholder Stable Diffusion calls
 - Simple setup script to create a virtual environment and install dependencies
 
 ## Getting Started
 
 Run `scripts/setup.sh` to create a virtual environment and install the required Python packages.
-Make sure an Ollama server is running locally to provide LLM completions.
+Make sure an Ollama server is running locally or set `OLLAMA_HOST` to point to your Ollama instance.
 Then launch the application:
 
 ```bash

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,6 +10,6 @@ python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
 pip install --upgrade pip
-pip install gradio
+pip install gradio ollama
 
 echo "Setup complete. Activate the virtual environment using: source $VENV_DIR/bin/activate"

--- a/synthmind/app.py
+++ b/synthmind/app.py
@@ -1,11 +1,16 @@
 import gradio as gr
 import socket
 import ollama
+import os
 import json
 from pathlib import Path
 
 PERSONA_DIR = Path(__file__).resolve().parent.parent / "persona"
 PERSONA_DIR.mkdir(exist_ok=True)
+
+# Ollama connection settings
+OLLAMA_HOST = os.getenv("OLLAMA_HOST")
+ollama_client = ollama.Client(host=OLLAMA_HOST)
 
 
 def list_personas():
@@ -75,13 +80,13 @@ def update_persona_list():
 # LLM integration with Ollama
 def list_llm_models():
     try:
-        return [m["name"] for m in ollama.list().get("models", [])]
+        return [m.model for m in ollama_client.list().models if m.model]
     except Exception:
         return []
 
 def download_llm_model(name):
     try:
-        ollama.pull(name)
+        ollama_client.pull(name)
         return f"Downloaded {name}"
     except Exception as e:
         return f"Error: {e}"
@@ -92,7 +97,7 @@ def generate_response(user_input, history, model):
         messages.insert(0, {"role": "assistant", "content": b})
         messages.insert(0, {"role": "user", "content": u})
     try:
-        resp = ollama.chat(model=model, messages=messages)
+        resp = ollama_client.chat(model=model, messages=messages)
         return resp["message"]["content"]
     except Exception as e:
         return f"Error: {e}"


### PR DESCRIPTION
## Summary
- configure Ollama client via `OLLAMA_HOST`
- update model functions to use the client
- add ollama to setup script
- document new environment variable in README

## Testing
- `python -m synthmind.app`

------
https://chatgpt.com/codex/tasks/task_e_6856dfcf48cc8333b5f04ed6a78590b6