### PR TITLE
Remove Ollama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ SynthMind is a multimodal chat application that combines a large language model 
 ## Features
 
 - Chat interface with tabs for Chat, Personas, App Settings, and Model Selection
-- Ollama-backed LLM integration with model downloader
+- Local LLM model listing from the `models/llm` directory
 - Placeholder Stable Diffusion calls
 - Simple setup script to create a virtual environment and install dependencies
 
 ## Getting Started
 
 Run `scripts/setup.sh` to create a virtual environment and install the required Python packages.
-Make sure an Ollama server is running locally to provide LLM completions.
 Then launch the application:
 
 ```bash

--- a/multi.md
+++ b/multi.md
@@ -17,7 +17,7 @@ Module im Detail:
 
 1. Text-LLM:
 Modell: Mistral-7B-Instruct (GGUF-Format, quantisiert)
-Backend: llama.cpp oder ollama
+Backend: llama.cpp
 Ausführung: CPU oder GPU (abhängig von Systemlast)
 Ziel: Durchführung natürlicher Textdialoge und Prompt-Interpretation
 


### PR DESCRIPTION
## Summary
- strip Ollama integration from app backend and UI
- keep model selection tab using local directory scanning
- adjust documentation to drop Ollama references
- update project plan

## Testing
- `pip install gradio`
- `python -m synthmind.app --help` *(shows launch message)*

------
https://chatgpt.com/codex/tasks/task_e_6856e31aa5288333b13fc7163e9c3a69