### PR TITLE
Add multimodal chat framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # SynthMind
 
-SynthMind is a multimodal chat application that combines a large language model (LLM) with a Stable Diffusion model. The interface is built with Gradio and styled like a chat application. The project currently provides a basic foundation with placeholder text and image generation.
+SynthMind is a multimodal chat application that combines a large language model (LLM) with a Stable Diffusion model. The interface is built with Gradio and styled like a chat application. The project currently provides a basic framework with placeholder implementations for text and image generation as well as image understanding.
 
 ## Features
 
 - Chat interface with tabs for Chat, Personas, App Settings, and Model Selection
 - Local LLM model listing from the `models/llm` directory
-- Placeholder Stable Diffusion calls
+- Image generation and image analysis modes in the chat window
+- Placeholder modules for the LLM, Stable Diffusion and vision model
 - Simple setup script to create a virtual environment and install dependencies
 
 ## Getting Started

--- a/synthmind/chat.py
+++ b/synthmind/chat.py
@@ -1,0 +1,20 @@
+"""Placeholder chat module for SynthMind."""
+
+from typing import List, Tuple, Optional
+
+
+def generate_response(user_input: str, history: List[Tuple[str, str]] | None = None, model: Optional[str] = None) -> str:
+    """Return a simple placeholder response.
+
+    Parameters
+    ----------
+    user_input: str
+        The user's text prompt.
+    history: list of tuples
+        Previous conversation history. Unused in this placeholder.
+    model: str | None
+        Name of the selected LLM model.
+    """
+    # In a real implementation this function would invoke the selected
+    # language model. For now, just echo the input.
+    return f"Echo: {user_input}"

--- a/synthmind/generator.py
+++ b/synthmind/generator.py
@@ -1,0 +1,26 @@
+"""Placeholder image generation module for SynthMind."""
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def generate_image(prompt: str, size: int = 512) -> Image.Image:
+    """Return a simple placeholder image with the prompt text.
+
+    Parameters
+    ----------
+    prompt: str
+        Text prompt for image generation.
+    size: int
+        Output image size in pixels (square).
+    """
+    # Create a blank image and draw the prompt text on it. This is just a
+    # stand-in for a Stable Diffusion call.
+    img = Image.new("RGB", (size, size), color="white")
+    draw = ImageDraw.Draw(img)
+    text = f"Generated:\n{prompt}"
+    try:
+        font = ImageFont.load_default()
+    except Exception:
+        font = None
+    draw.multiline_text((10, 10), text, fill="black", font=font)
+    return img

--- a/synthmind/vision.py
+++ b/synthmind/vision.py
@@ -1,0 +1,17 @@
+"""Placeholder vision module for SynthMind."""
+
+from PIL import Image
+
+
+def analyze_image(image: Image.Image) -> str:
+    """Return a simple description of the uploaded image.
+
+    Parameters
+    ----------
+    image: PIL.Image.Image
+        Image to analyze.
+    """
+    if image is None:
+        return "No image provided."
+    width, height = image.size
+    return f"Received an image of size {width}x{height}px"


### PR DESCRIPTION
## Summary
- implement placeholder modules for chat, vision and image generation
- extend Gradio interface with modes for chatting, generating images and analyzing uploaded images
- update README

## Testing
- `bash scripts/setup.sh`
- `python -m py_compile synthmind/app.py synthmind/chat.py synthmind/generator.py synthmind/vision.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e4867a3c8333867be4d0b6f7e98e