### PR TITLE
Fix installer Git URL

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-REPO_URL="https://github.com/yourusername/SynthMind.git"
+REPO_URL="https://github.com/AsaTyr2018/SynthMind.git"
 DEFAULT_INSTALL_DIR_LINUX="/opt/SynthMind"
 
 run() {


### PR DESCRIPTION
## Summary
- use repository HTTPS URL directly in installer

## Testing
- `bash scripts/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856ec99e4688333a9b45bc6a9974038