### PR TITLE
Fix persona state management with new Gradio

### DIFF
--- a/synthmind/app.py
+++ b/synthmind/app.py
@@ -160,6 +160,9 @@ def get_local_ip() -> str:
 theme = gr.themes.Soft(primary_hue="orange")
 
 with gr.Blocks(theme=theme) as demo:
+    # Register persona_state so Gradio tracks it properly.
+    persona_state.render()
+
     gr.Markdown("# SynthMind")
     with gr.Tab("Chat"):
         with gr.Column():


### PR DESCRIPTION
## Summary
- register `persona_state` in the Gradio Blocks context so state updates work on newer Gradio versions

## Testing
- `python -m py_compile synthmind/*.py`
- `python -m synthmind.app` *(interrupted after server start)*

------
https://chatgpt.com/codex/tasks/task_e_6856fee0d90c833381271c836ae428b5